### PR TITLE
fix: exception in new layout test cases

### DIFF
--- a/src/rules/layout-token-use/__tests__/index.js
+++ b/src/rules/layout-token-use/__tests__/index.js
@@ -479,27 +479,31 @@ testRule(rule, {
   reject: [
     {
       code: `.foo { $body--height: 400px; top: -($body--height - $carbon--spacing-05); }`,
-      description: `See if ths works`,
+      description: `Reject non-supported maths of form $x: 1px; -($x - $token)`,
     },
     {
       code: `.foo { top: -($body--height - $carbon--spacing-05); }`,
-      description: `See if ths works`,
+      description: `Reject non-supported maths of form -($unknown - $token)`,
     },
     {
       code: `.foo { $body--height: 400px; top: ($body--height - $carbon--spacing-05); }`,
-      description: `See if ths works`,
+      description: `Reject non-supported maths of form $x: 1px; ($x - $token)`,
     },
     {
       code: `.foo { top: ($body--height - $carbon--spacing-05); }`,
-      description: `See if ths works`,
+      description: `Reject non-supported maths of form ($unknown - $token)`,
     },
     {
       code: `.foo { $body--height: 400px; top: $body--height - $carbon--spacing-05; }`,
-      description: `See if ths works`,
+      description: `Reject non-supported maths of form $x: 1px; $x - $token`,
     },
     {
       code: `.foo { top: $body--height - $carbon--spacing-05; }`,
-      description: `See if ths works`,
+      description: `Reject non-supported maths of form $unknown - $token`,
+    },
+    {
+      code: `.foo {margin-top: 1 + map-get($map: (key: 1rem), $key: key);}`,
+      description: "Reject 1 + map-get",
     },
   ],
 });

--- a/src/utils/tokenizeValue.js
+++ b/src/utils/tokenizeValue.js
@@ -230,11 +230,25 @@ const processTokens = (tokens) => {
         ? result.items[result.items.length - 1]
         : undefined;
 
+    // we are going into bracketed content (array has no input property)
     if (token && token.input === undefined) {
-      // we are going into bracketed content
-      if (lastItem && lastItem.type === TOKEN_TYPES.TEXT_LITERAL) {
+      const lastItemLiteral =
+        lastItem && lastItem.type === TOKEN_TYPES.TEXT_LITERAL;
+      const lastItemMathLiteral =
+        lastItem &&
+        lastItem.type === TOKEN_TYPES.MATH &&
+        lastItem.items[lastItem.items.length - 1].type ===
+          TOKEN_TYPES.TEXT_LITERAL;
+
+      if (lastItemLiteral || lastItemMathLiteral) {
         // update existing item
-        item = lastItem;
+        if (lastItemLiteral) {
+          item = lastItem;
+        } else {
+          item = lastItem.items[lastItem.items.length - 1];
+          lastItem.raw += "(";
+        }
+
         item.items = [];
         item.type = TOKEN_TYPES.FUNCTION;
         item.isCalc = lastItem.value === "calc";


### PR DESCRIPTION
Prevent the following test cases from causing the linter to error out. This does not add any support for map-get or any of the following test cases.

```js
// Additional  test for reported issue
// top: -($body--height - $carbon--spacing-05);
testRule(rule, {
  ruleName,
  config: true,
  syntax: "scss",
  reject: [
    {
      code: `.foo { $body--height: 400px; top: -($body--height - $carbon--spacing-05); }`,
      description: `Reject non-supported maths of form $x: 1px; -($x - $token)`,
    },
    {
      code: `.foo { top: -($body--height - $carbon--spacing-05); }`,
      description: `Reject non-supported maths of form -($unknown - $token)`,
    },
    {
      code: `.foo { $body--height: 400px; top: ($body--height - $carbon--spacing-05); }`,
      description: `Reject non-supported maths of form $x: 1px; ($x - $token)`,
    },
    {
      code: `.foo { top: ($body--height - $carbon--spacing-05); }`,
      description: `Reject non-supported maths of form ($unknown - $token)`,
    },
    {
      code: `.foo { $body--height: 400px; top: $body--height - $carbon--spacing-05; }`,
      description: `Reject non-supported maths of form $x: 1px; $x - $token`,
    },
    {
      code: `.foo { top: $body--height - $carbon--spacing-05; }`,
      description: `Reject non-supported maths of form $unknown - $token`,
    },
    {
      code: `.foo {margin-top: 1 + map-get($map: (key: 1rem), $key: key);}`,
      description: "Reject 1 + map-get",
    },
  ],
});
```