### PR TITLE
fix: dissalow missing values

### DIFF
--- a/src/rules/motion-duration-use/__tests__/index.js
+++ b/src/rules/motion-duration-use/__tests__/index.js
@@ -93,12 +93,14 @@ testRule(rule, {
     },
     {
       code: ".foo { transition: $duration-fast-01; }",
-      description: "Carbon motion token used in non-standard order.",
+      description:
+        "Carbon motion token used in non-standard order with transition.",
       message: messages.expected
     },
     {
       code: ".foo { animation: $duration-fast-01 test; }",
-      description: "Carbon motion token used in non-standard order.",
+      description:
+        "Carbon motion token used in non-standard order with animation.",
       message: messages.expected
     },
     {

--- a/src/rules/motion-easing-use/__tests__/index.js
+++ b/src/rules/motion-easing-use/__tests__/index.js
@@ -13,10 +13,6 @@ testRule(rule, {
   customSyntax: "postcss-scss",
   accept: [
     {
-      code: ".foo {   transition: background-color $duration-slow-02; }",
-      description: "Accept no easing for transition."
-    },
-    {
       code: ".foo {   transition: background-color $duration-slow-02 $ease-in; }",
       description:
         "Carbon motion easing token settings expected for transition."
@@ -72,6 +68,14 @@ testRule(rule, {
     }
   ],
   reject: [
+    {
+      code: ".foo {   transition: $ease-in; }",
+      description: "Reject easing when other values are missing missing."
+    },
+    {
+      code: ".foo {   transition: background-color $duration-slow-02; }",
+      description: "Reject no easing for transition when value is missing."
+    },
     {
       code: ".foo { transition: width $duration-fast-01 ease-in, height 2s ease-out; }",
       description: "Reject non Carbon ease token or function",

--- a/src/utils/checkRule.js
+++ b/src/utils/checkRule.js
@@ -98,7 +98,8 @@ export default async function checkRule(
       itemsToCheck = [];
 
       start = parseRangeValue(start, items.length);
-      end = end !== undefined ? parseRangeValue(end, items.length) : start;
+      // missing value equates to incorrect ordering
+      end = parseRangeValue(end, items.length);
 
       if (end) {
         itemsToCheck.push(...items.slice(start, end + 1)); // +1 as slice end is not inclusive


### PR DESCRIPTION
Allowing missing values causes problems with identifying what type a value should match e.g. duration or easing.

This change effectively reverts a recent change.