### PR TITLE
chore: release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.0
+
+- Released after testing in @carbon/ibm-products
+
 ## 2.0.0-rc.0
 
 - Makes use of `unstable_metadata` now available in @carbon/themes version 11.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-plugin-carbon-tokens",
-  "version": "2.0.0-rc.0",
+  "version": "2.0.0",
   "description": "A stylelint plugin to support the use of carbon component tokens.",
   "keywords": [
     "stylelint",


### PR DESCRIPTION
🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 🎉 

Gave it a quick test in @carbon/ibm-products and decided to push the big red button 🔴 ⏯️ which there is no icon for 😱 