### PR TITLE
fix: issue 89

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,14 @@
   "license": "MIT",
   "babel": {
     "presets": [
-      "@babel/env"
+      [
+        "@babel/env",
+        {
+          "targets": {
+            "node": "14"
+          }
+        }
+      ]
     ]
   },
   "bugs": {


### PR DESCRIPTION
Fixes #89

Node 14 is in maintenance until April 2023, hence changing babel target to 14.