### PR TITLE
feat: add all scopes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,17 +137,18 @@ It's good practice to document any linter disables and to tidy up any that are n
 ```js
   rules: {
     // ADDED TO TEST CARBON USE
-    'carbon/layout-token-use': [true, { severity: 'warning', acceptUndefinedVariables: true  }],
-    'carbon/motion-duration-use': [true, { severity: 'warning', acceptUndefinedVariables: true  }],
-    "carbon/motion-easing-use": [true, { severity: 'warning', acceptUndefinedVariables: true }],
-    'carbon/theme-token-use': [true, { severity: 'warning', acceptUndefinedVariables: true  }],
+    'carbon/layout-token-use': [true, { severity: 'warning', acceptUndefinedVariables: true, acceptScopes: ['**']  }],
+    'carbon/motion-duration-use': [true, { severity: 'warning', acceptUndefinedVariables: true, acceptScopes: ['**']  }],
+    "carbon/motion-easing-use": [true, { severity: 'warning', acceptUndefinedVariables: true, acceptScopes: ['**'] }],
+    'carbon/theme-token-use': [true, { severity: 'warning', acceptUndefinedVariables: true, acceptScopes: ['**']  }],
     'carbon/type-token-use': [
       true,
       {
         severity: 'warning',
         acceptCarbonTypeScaleFunction: true,
         acceptCarbonFontWeightFunction: true,
-        acceptUndefinedVariables: true
+        acceptUndefinedVariables: true,
+        acceptScopes: ['**']
       },
     ],
   },
@@ -215,6 +216,8 @@ The acceptValues option allows you to check your own tokens refer to values acce
 - `acceptValues: ["$/^\\$my-color--/"]` - Accept SCSS variables starting "\$my-color--"
 
 The acceptScopes option allows you to alter the scope value for all rules using regex or a string. For example you may wish to use short scope names.
+
+- `acceptScopes: ["**"]` - accept all scopes
 
 - `acceptScopes: ["/^la(yout)?$/", "/^mo(tion)?$/", "/^th(eme)?$/", "/^ty(pe)?$/"]` - using regex to accept abbreviations
 - `acceptScopes: ["la", "mo", "th", "ty"]` - abbreviations but not defaults

--- a/src/rules/layout-token-use/__tests__/index.js
+++ b/src/rules/layout-token-use/__tests__/index.js
@@ -913,3 +913,15 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+  config: [true, { acceptScopes: ["**"] }],
+  configSyntax: "postcss-scss",
+  accept: [
+    {
+      code: `.foo { left: abcd.$spacing-05; right: zyx.$spacing-05;}`,
+      description: "All scopes ['**']."
+    }
+  ]
+});

--- a/src/rules/motion-duration-use/__tests__/index.js
+++ b/src/rules/motion-duration-use/__tests__/index.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import rule, {  messages, ruleName } from "..";
+import rule, { messages, ruleName } from "..";
 
 testRule(rule, {
   ruleName,
@@ -126,7 +126,10 @@ testRule(rule, {
 // v10 test
 testRule(rule, {
   ruleName,
-  config: [true, { carbonPath: "node_modules/@carbon", carbonModulePostfix: "-10" }],
+  config: [
+    true,
+    { carbonPath: "node_modules/@carbon", carbonModulePostfix: "-10" }
+  ],
   customSyntax: "postcss-scss",
   accept: [
     {
@@ -273,6 +276,18 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: [true, { acceptScopes: ["**"] }],
+  customSyntax: "postcss-scss",
+  accept: [
+    {
+      code: `.foo { animation-duration: abc.$duration-fast-01; transition-duration: zyx.$duration-fast-01;}`,
+      description: "All scopes ['**']."
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
   customSyntax: "postcss-scss",
   fix: true,
   config: true,
@@ -349,37 +364,40 @@ testRule(rule, {
   ruleName,
   customSyntax: "postcss-scss",
   fix: true,
-  config: [true, { carbonPath: "node_modules/@carbon", carbonModulePostfix: "-10" }],
+  config: [
+    true,
+    { carbonPath: "node_modules/@carbon", carbonModulePostfix: "-10" }
+  ],
   reject: [
-  {
-    code: `.foo { transition: all 70ms; }`,
-    fixed: `.foo { transition: all $duration--fast-01; }`,
-    description: "v11 reject and fix literal duration matching token '70ms'"
-  },
-  {
-    code: `.foo { transition: all 110ms; }`,
-    fixed: `.foo { transition: all $duration--fast-02; }`,
-    description: "v11 reject and fix literal duration matching token '110ms'"
-  },
-  {
-    code: `.foo { transition: all 150ms; }`,
-    fixed: `.foo { transition: all $duration--moderate-01; }`,
-    description: "v11 reject and fix literal duration matching token '150ms'"
-  },
-  {
-    code: `.foo { transition: all 240ms; }`,
-    fixed: `.foo { transition: all $duration--moderate-02; }`,
-    description: "v11 reject and fix literal duration matching token '240ms'"
-  },
-  {
-    code: `.foo { transition: all 400ms; }`,
-    fixed: `.foo { transition: all $duration--slow-01; }`,
-    description: "v11 reject and fix literal duration matching token '400ms'"
-  },
-  {
-    code: `.foo { transition: all 700ms; }`,
-    fixed: `.foo { transition: all $duration--slow-02; }`,
-    description: "v11 reject and fix literal duration matching token '700ms'"
-  }
+    {
+      code: `.foo { transition: all 70ms; }`,
+      fixed: `.foo { transition: all $duration--fast-01; }`,
+      description: "v11 reject and fix literal duration matching token '70ms'"
+    },
+    {
+      code: `.foo { transition: all 110ms; }`,
+      fixed: `.foo { transition: all $duration--fast-02; }`,
+      description: "v11 reject and fix literal duration matching token '110ms'"
+    },
+    {
+      code: `.foo { transition: all 150ms; }`,
+      fixed: `.foo { transition: all $duration--moderate-01; }`,
+      description: "v11 reject and fix literal duration matching token '150ms'"
+    },
+    {
+      code: `.foo { transition: all 240ms; }`,
+      fixed: `.foo { transition: all $duration--moderate-02; }`,
+      description: "v11 reject and fix literal duration matching token '240ms'"
+    },
+    {
+      code: `.foo { transition: all 400ms; }`,
+      fixed: `.foo { transition: all $duration--slow-01; }`,
+      description: "v11 reject and fix literal duration matching token '400ms'"
+    },
+    {
+      code: `.foo { transition: all 700ms; }`,
+      fixed: `.foo { transition: all $duration--slow-02; }`,
+      description: "v11 reject and fix literal duration matching token '700ms'"
+    }
   ]
 });

--- a/src/rules/motion-easing-use/__tests__/index.js
+++ b/src/rules/motion-easing-use/__tests__/index.js
@@ -142,23 +142,35 @@ testRule(rule, {
   ]
 });
 
-// testRule(rule, {
-//   ruleName,
-//   config: [true, { acceptScopes: ["mo"] }],
-//   customSyntax: "postcss-scss",
-//   accept: [
-//     {
-//       code: ".foo {   transition: background-color $duration-slow-02 mo.$ease-in; }",
-//       description:
-//         "Expected scope 'mo' motion easing token settings expected for transition."
-//     },
-//     {
-//       code: ".foo {   transition: background-color $duration-slow-02 mo.motion(exit, expressive); }",
-//       description:
-//         "Expected scope 'mo' motion easing function settings expected for transition."
-//     }
-//   ]
-// });
+testRule(rule, {
+  ruleName,
+  config: [true, { acceptScopes: ["mo"] }],
+  customSyntax: "postcss-scss",
+  accept: [
+    {
+      code: ".foo {   transition: background-color $duration-slow-02 mo.$ease-in; }",
+      description:
+        "Expected scope 'mo' motion easing token settings expected for transition."
+    },
+    {
+      code: ".foo {   transition: background-color $duration-slow-02 mo.motion(exit, expressive); }",
+      description:
+        "Expected scope 'mo' motion easing function settings expected for transition."
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: [true, { acceptScopes: ["**"] }],
+  customSyntax: "postcss-scss",
+  accept: [
+    {
+      code: ".foo {   transition: background-color $duration-slow-02 abc.$ease-in; } .bar {   transition: background-color $duration-slow-02 zyx.$ease-in; }",
+      description: "All scopes ['**']."
+    }
+  ]
+});
 
 testRule(rule, {
   ruleName,

--- a/src/rules/theme-token-use/__tests__/index.js
+++ b/src/rules/theme-token-use/__tests__/index.js
@@ -526,6 +526,18 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: [true, { acceptScopes: ["**"] }],
+  customSyntax: "postcss-scss",
+  accept: [
+    {
+      code: `.foo { color: abc.$layer-01; border-color: zyx.$layer-01; }`,
+      description: "All scopes ['**']."
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
   config: true,
   customSyntax: "postcss-scss",
   accept: [

--- a/src/utils/testItem.js
+++ b/src/utils/testItem.js
@@ -33,6 +33,11 @@ const sanitizeUnconnectedOperators = (val) => {
 };
 
 const checkScope = (item, options) => {
+  if (options.acceptScopes[0] === "**") {
+    // ** means all scopes
+    return true;
+  }
+
   return options.acceptScopes.some((acceptedScope) => {
     const testValue = parseToRegexOrString(acceptedScope);
 


### PR DESCRIPTION
Resolves #85.

Allows the user accept all scopes with:

`acceptScopes: ["**"]`