### PR TITLE
Fix deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.2.1
+
+- fix: deprecation warnings caused by use of `content.fix` following
+  https://stylelint.io/changelog/#1682.
+
 ## 3.2.0
 
 - chore: bump versions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-plugin-carbon-tokens",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A stylelint plugin to support the use of carbon component tokens.",
   "keywords": [
     "stylelint",

--- a/src/utils/checkRule.js
+++ b/src/utils/checkRule.js
@@ -312,10 +312,10 @@ export default async function checkRule(
         }
 
         // *** found issues try to fix and report if not fixed
-        if (reports.length > 0) {
+        const fixFunction = () => {
           let fixed = false;
 
-          if (context && context.fix && ruleInfo.fixes) {
+          if (context && ruleInfo.fixes) {
             let workingValue = decl.value;
 
             // try to fix
@@ -366,14 +366,12 @@ export default async function checkRule(
               }
             }
           }
+          return fixed;
+        };
 
-          if (!fixed) {
-            // always report original warnings not those based on fix
-            reports.forEach((report) => {
-              utils.report(report);
-            });
-          }
-        }
+        reports.forEach((report) => {
+          utils.report({ ...report, fix: fixFunction });
+        });
       }
     }
   });


### PR DESCRIPTION
## 3.2.1

- fix: deprecation warnings caused by use of `content.fix` following
  https://stylelint.io/changelog/#1682.