### PR TITLE
fix: resolve v17 stylelint and vscode issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 4.0.6
+
+- fix: Resolve Stylelint v17 + vscode-stylelint v2.0.0 circular reference issue
+  - Clean all PostCSS nodes in the AST tree before processing to remove circular
+    references from postcss-scss's Lexer
+  - This fixes the "Converting circular structure to JSON" error in VSCode/Bob
+    when using vscode-stylelint v2.0.0 with Stylelint v17
+  - Related to Stylelint issue #8964
+  - The fix ensures compatibility with the "Stylelint 17 way" of handling custom
+    syntaxes
+
 ## 4.0.5
 
 - fix: Completely resolve circular structure JSON serialization error in VSCode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-plugin-carbon-tokens",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "A stylelint plugin to support the use of carbon component tokens.",
   "keywords": [
     "stylelint",


### PR DESCRIPTION
OK. There is an issue with Stylelint VSCode plugin v2.0.0, update to 2.0.1 or later. Open VSX is behind, so downloading VSX from Microsoft Marketplace is simplest solution.

This code tidying up how we work with V17 is still useful.